### PR TITLE
Fix the incorrect format of go directive #39

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/open-ness/edgecontroller
 
-go 1.14.2
+go 1.14
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0


### PR DESCRIPTION
Fix the incorrect format of go directive in go.mod file according to [Go Modules Reference](https://golang.org/ref/mod#tmp_12%). This incorrect format of go directive will causes Golang command tool "go mod download" fail when the Golang version is 1.14 or higher. Many Ansible tasks in openness-experience-kits project will use this Golang command tool "go mod download" before building Golang binary, and other external tools depending on go.mod file will not work in this project when the Golang version is 1.14 or higher.


